### PR TITLE
output directory must already pre-exist

### DIFF
--- a/phyloGenerator.py
+++ b/phyloGenerator.py
@@ -1905,6 +1905,7 @@ class PhyloGenerator:
 			if 'phyloGenerator.app/Contents/Resources' in temp:
 				temp = temp.replace('phyloGenerator.app/Contents/Resources', '')
 			print "\nPlease input a working directory for all your output"
+			print "The specified directory must already pre-exist"
 			print "\t(hit enter to use " + temp
 			self.workingDirectory = raw_input("Working directory (" + temp + "): ")
 			if not self.workingDirectory:


### PR DESCRIPTION
If 'foo' directory doesn't exist and you specify 'foo' here you get an error later on...

DNA Editing (delete): output
Traceback (most recent call last):
  File "./phyloGenerator.py", line 3790, in <module>
    main()
  File "./phyloGenerator.py", line 3736, in main
    currentState.dnaEditing()
  File "./phyloGenerator.py", line 2691, in dnaEditing
    mode, firstTime = deleteMode(firstTime)
  File "./phyloGenerator.py", line 2183, in deleteMode
    os.chdir(self.workingDirectory)
OSError: [Errno 2] No such file or directory: 'foo'
